### PR TITLE
feat: initial monorepo setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 # API
 PORT=8080
-DB_DSN=host=db user=*** password=*** dbname=***** port=5432 sslmode=disable TimeZone=Asia/Jakarta
+DB_DSN=host=db user=app password=app dbname=appdb port=5432 sslmode=disable TimeZone=Asia/Jakarta
 REDIS_ADDR=redis:6379
-JWT_ACCESS_SECRET=**********
-JWT_REFRESH_SECRET=**********
+JWT_ACCESS_SECRET=dev_access_secret_change
+JWT_REFRESH_SECRET=dev_refresh_secret_change
 JWT_ACCESS_TTL=15m
 JWT_REFRESH_TTL=168h
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Node
+node_modules
+.next
+dist
+
+# Go
+bin
+*.exe
+*.out
+
+# Docker volume
+db_data

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# SiKoder
+
+Platform belajar HTML/CSS/JS dengan gamifikasi berbasis Blockly.
+
+## Development
+
+1. Salin file env: `cp .env.example .env`
+2. Jalankan semua service: `docker compose up --build`
+
+## Akses
+
+- Web: http://localhost:3000
+- API: http://localhost:8080/v1/health

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func main() {
+	app := fiber.New()
+
+	app.Get("/v1/health", func(c *fiber.Ctx) error {
+		return c.JSON(fiber.Map{"status": "ok"})
+	})
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	log.Fatal(app.Listen(":" + port))
+}

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,0 +1,5 @@
+module github.com/sikoder/api
+
+go 1.22
+
+require github.com/gofiber/fiber/v2 v2.52.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 version: "3.9"
+
 services:
   db:
     image: postgres:16-alpine
@@ -6,36 +7,40 @@ services:
       POSTGRES_USER: app
       POSTGRES_PASSWORD: app
       POSTGRES_DB: appdb
-    volumes: [ "db_data:/var/lib/postgresql/data" ]
-    ports: [ "5432:5432" ]
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U app -d appdb"]
-      interval: 5s
-      retries: 5
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
 
   redis:
     image: redis:7-alpine
-    ports: [ "6379:6379" ]
+    ports:
+      - "6379:6379"
 
   api:
     build: ./api
-    depends_on: [ db, redis ]
+    depends_on:
+      - db
+      - redis
     environment:
+      PORT: ${PORT}
       DB_DSN: ${DB_DSN}
       REDIS_ADDR: ${REDIS_ADDR}
       JWT_ACCESS_SECRET: ${JWT_ACCESS_SECRET}
       JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
       JWT_ACCESS_TTL: ${JWT_ACCESS_TTL}
       JWT_REFRESH_TTL: ${JWT_REFRESH_TTL}
-      PORT: ${PORT}
-    ports: [ "8080:8080" ]
+    ports:
+      - "8080:8080"
 
   web:
     build: ./web
-    depends_on: [ api ]
+    depends_on:
+      - api
     environment:
       NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL}
-    ports: [ "3000:3000" ]
+    ports:
+      - "3000:3000"
 
 volumes:
   db_data:


### PR DESCRIPTION
## Summary
- scaffold monorepo with Dockerized Go API and Next.js web app
- add health endpoint and environment samples
- document development workflow and ignore common build artifacts

## Testing
- `go build ./cmd/api` *(fails: missing go.sum entry for module providing package github.com/gofiber/fiber/v2)*
- `npm ci` *(fails: The `npm ci` command can only install with an existing package-lock.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b12a32e37c8333a402bb64116fdbae